### PR TITLE
DOM data elements

### DIFF
--- a/state.js
+++ b/state.js
@@ -8,14 +8,16 @@
 exports.state = function (event, data) {
 
     // check if state exists
-    if (this.states[data.name]) {
+    if (this.tmpl && this.states[data.name]) {
 
         // activate state elements
-        for (var i = 0, state, selector; i < this.states[data.name].length; ++i) {
+        for (var i = 0, state, selector, element; i < this.states[data.name].length; ++i) {
             state = this.states[data.name][i];
+            element = this.tmpl.elements[data.element || state.element];
+            selector = state.sel || data.selector;
 
             // get dynamic or static selector
-            if (!(selector = state.sel || data.selector) || !this.tmpl) {
+            if (!element && !selector) {
 
                 // retrun if no selector is found
                 return;
@@ -33,7 +35,7 @@ exports.state = function (event, data) {
 
             // manipulate classes
             selector = typeof selector !== 'string' ? selector : (this.tmpl.to || document).querySelectorAll(selector);
-            manipulateClasses(selector, state);
+            manipulateClasses(element || selector, state);
         }
     }
 };

--- a/view.js
+++ b/view.js
@@ -247,8 +247,9 @@ function setupDomEventFlow (module_instance) {
         flow = module_instance._extFlow[i];
         
         // handle element config
-        /*if (flow.element && module_instance.tmpl[flow.element]) {
-            module_instance.tmpl[flow.element].addEventListener(
+        if (flow.element && module_instance.tmpl.elements[flow.element]) {
+            var element = module_instance.tmpl.elements[flow.element];
+            element.addEventListener(
                 flow['in'],
                 engine.flow(
                     module_instance,
@@ -256,15 +257,17 @@ function setupDomEventFlow (module_instance) {
                     {
                         handler: domEventAdapter,
                         data: {
-                            scope: scope[s],
-                            data: data[s],
-                            elms: elms,
+                            scope: module_instance.tmpl.to,
+                            data: data[0],
+                            elms: [element],
                             dontPrevent: flow.dontPrevent
                         }
                     }
                 )
             );
-        }*/
+            
+            continue;
+        }
         
         // overwrite scope with the document
         if (flow.scope === 'global') {

--- a/view.js
+++ b/view.js
@@ -32,7 +32,8 @@ exports.init = function () {
             'k': tmpl.leaveKeys,
             'f': default_escape_fn,
             '_elmName': tmpl.element || default_element_name,
-            'element': '[data-' + (tmpl.element || default_element_name) + ']'
+            'element': '[data-' + (tmpl.element || default_element_name) + ']',
+            'elements': {}
         };
 
         // add page selector to template
@@ -137,7 +138,6 @@ exports.render = function (event, data) {
         // get available elements
         var elements = template.to.querySelectorAll(template.element);
         if (elements.length) {
-            template.elements = {};
             for (var e = 0, l = elements.length; e < l; ++e) {
                 template.elements[elements[e].dataset[template._elmName]] = elements[e];
             }

--- a/view.js
+++ b/view.js
@@ -2,6 +2,7 @@
 var engine = E;
 var state = require('./state');
 
+var default_element_name = 'element';
 var template_escape = {"\\": "\\\\", "\n": "\\n", "\r": "\\r", "'": "\\'"};
 var render_escape = {'&': '&amp;', '"': '&quot;', '<': '&lt;', '>': '&gt;'};
 
@@ -30,7 +31,8 @@ exports.init = function () {
             'e': tmpl.dontEscape,
             'k': tmpl.leaveKeys,
             'f': default_escape_fn,
-            'element': '[' + (tmpl.element || 'data-element') + ']'
+            '_elmName': tmpl.element || default_element_name,
+            'element': '[data-' + (tmpl.element || default_element_name) + ']'
         };
 
         // add page selector to template
@@ -137,7 +139,7 @@ exports.render = function (event, data) {
         if (elements.length) {
             template.elements = {};
             for (var e = 0, l = elements.length; e < l; ++e) {
-                template.elements[elements[e].dataset.element] = elements[e];
+                template.elements[elements[e].dataset[template._elmName]] = elements[e];
             }
         }
     }

--- a/view.js
+++ b/view.js
@@ -29,7 +29,8 @@ exports.init = function () {
             'to': tmpl.to,
             'e': tmpl.dontEscape,
             'k': tmpl.leaveKeys,
-            'f': default_escape_fn
+            'f': default_escape_fn,
+            'element': '[' + (tmpl.element || 'data-element') + ']'
         };
 
         // add page selector to template
@@ -130,6 +131,15 @@ exports.render = function (event, data) {
     // render html
     if (!dontAppend && template.to) {
         template.to.innerHTML = template.html;
+        
+        // get available elements
+        var elements = template.to.querySelectorAll(template.element);
+        if (elements.length) {
+            template.elements = {};
+            for (var e = 0, l = elements.length; e < l; ++e) {
+                template.elements[elements[e].dataset.element] = elements[e];
+            }
+        }
     }
 
     // append dom events
@@ -233,7 +243,27 @@ function setupDomEventFlow (module_instance) {
 
     for (var i = 0, flow; i < module_instance._extFlow.length; ++i) {
         flow = module_instance._extFlow[i];
-
+        
+        // handle element config
+        /*if (flow.element && module_instance.tmpl[flow.element]) {
+            module_instance.tmpl[flow.element].addEventListener(
+                flow['in'],
+                engine.flow(
+                    module_instance,
+                    flow.out,
+                    {
+                        handler: domEventAdapter,
+                        data: {
+                            scope: scope[s],
+                            data: data[s],
+                            elms: elms,
+                            dontPrevent: flow.dontPrevent
+                        }
+                    }
+                )
+            );
+        }*/
+        
         // overwrite scope with the document
         if (flow.scope === 'global') {
             scope = [document];


### PR DESCRIPTION
Create a specification to get "elements" from the rendered html. Which then can be easily used in the `extFlow` collection.
Example HTML data attribute:

``` html
<div data-element="myIdentifier"></div>
```

Example `state` instance config:
(`element` is the name of the data attribute: `<div data-[customDataAttr]="myElement"></div>`)

``` json
{
    "template": {
        "to": "#main-nav",
        "html": "/nav_main_public.html",
        "render": true,
        "element": "customDataAttr"
    }
}
```

Example `extFlow` config:

``` json
{
    "in": "click",
    "element": "myElement",
    "out": [{}]
}
```

Example `state` call config:

``` json
{
    "call": "state",
    "data": {
        "name": "stateName",
        "element": "{_path.0}"
    }
}
```

Fixes #3 
