### PR TITLE
Always query for the element in the current DOM

### DIFF
--- a/view.js
+++ b/view.js
@@ -103,7 +103,10 @@ function draw (err, renderObj) {
 
     // get dom parent
     if (typeof template.to === 'string') {
-        template.to = document.querySelector(template.to);
+        template._to = template.to;
+    }
+    if (typeof template._to === 'string') {
+        template.to = document.querySelector(template._to);
     }
 
     // render html


### PR DESCRIPTION
If the element reference is removed from the page then the `to` configuration doesen't work anymore.
